### PR TITLE
Allow user provide username/password to authenticate

### DIFF
--- a/istore_heatpump/__init__.py
+++ b/istore_heatpump/__init__.py
@@ -6,37 +6,42 @@ from homeassistant.exceptions import ConfigEntryNotReady
 
 from .api import iStoreApi
 from .coordinator import iStoreCoordinator
-from .const import DOMAIN
+from .const import (DOMAIN, CONF_USERNAME, CONF_PASSWORD, CONF_ACCESS_TOKEN, CONF_PARENT_ID, CONF_MDM_ID)
+
+PLATFORMS = ["sensor", "switch", "binary_sensor"]
+
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Set up iStore Heat Pump."""
+    """Set up iStore Heat Pump from a config entry."""
 
-    access_token = entry.data["access_token"]
-    parent_id = entry.data["parent_id"]
-    mdm_id = entry.data["mdm_id"]
+    api = iStoreApi(
+        username=entry.data[CONF_USERNAME],
+        password=entry.data[CONF_PASSWORD],
+        access_token=entry.data[CONF_ACCESS_TOKEN],
+        parent_id=entry.data[CONF_PARENT_ID],
+        mdm_id=entry.data[CONF_MDM_ID],
+        hass=hass,
+    )
 
-    api = iStoreApi(access_token, parent_id, mdm_id, hass)
     coordinator = iStoreCoordinator(hass, api)
 
-    # First refresh
+    # First refresh — raises ConfigEntryNotReady on failure
     await coordinator.async_config_entry_first_refresh()
 
-    # Store data PROPERLY
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         "api": api,
         "coordinator": coordinator,
     }
 
-    # Load sensor + switch platforms
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor", "switch", "binary_sensor"])
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Unload iStore."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, ["sensor", "switch", "binary_sensor"])
+    """Unload iStore Heat Pump config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/istore_heatpump/api.py
+++ b/istore_heatpump/api.py
@@ -1,56 +1,256 @@
-import aiohttp
+from __future__ import annotations
+
+import base64
 import logging
+import aiohttp
+
+from cryptography.hazmat.primitives import serialization, hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.backends import default_backend
 
 _LOGGER = logging.getLogger(__name__)
 
+# ──────────────────────────────────────────────────────────────────────────────
+# Authentication helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def _get_public_key(session: aiohttp.ClientSession) -> tuple[str, str]:
+    """Return (publicKey_b64, strategy) from the iStore public-key endpoint."""
+    url = f"https://home.istore.net.au/hossain-bff/framework/v1.0/user/public-key"
+    async with session.get(url) as resp:
+        body = await resp.json(content_type=None)
+        if body.get("code") != 0:
+            raise Exception(f"public-key API error: {body}")
+        data = body["data"]
+        return data["publicKey"], data["strategy"]
+
+
+def _encrypt_password(public_key_b64: str, password: str) -> str:
+    """Encrypt password with the server's RSA public key.
+
+    iStore uses RSA OAEP with SHA-256 for BOTH the main hash AND the MGF1 hash.
+    """
+    key_der = base64.b64decode(public_key_b64)
+    public_key = serialization.load_der_public_key(key_der, backend=default_backend())
+    encrypted = public_key.encrypt(
+        password.encode("utf-8"),
+        padding.OAEP(
+            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+            algorithm=hashes.SHA256(),
+            label=None,
+        ),
+    )
+    return base64.b64encode(encrypted).decode("utf-8")
+
+
+async def _login(
+    session: aiohttp.ClientSession, strategy: str, username: str, encrypted_password: str
+) -> tuple[str, str]:
+    """POST /user/login — returns (access_token, org_id)."""
+    url = f"https://home.istore.net.au/hossain-bff/framework/v1.0/user/login"
+    payload = {
+        "strategy": strategy,
+        "account": username,
+        "password": encrypted_password,
+    }
+    async with session.post(url, json=payload) as resp:
+        body = await resp.json(content_type=None)
+        _LOGGER.debug("login response: %s", body)
+        if body.get("code") != 0:
+            raise Exception(f"login failed: {body.get('message', body)}")
+        data = body["data"]
+        access_token = data["accessToken"]
+        org_id = data["organizations"][0]["id"]
+        return access_token, org_id
+
+
+async def _set_session(
+    session: aiohttp.ClientSession, access_token: str, org_id: str
+) -> str:
+    """POST /user/set-session — returns companyId."""
+    url = f"https://home.istore.net.au/hossain-bff/framework/v1.0/user/set-session"
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with session.post(url, json={"orgId": org_id}, headers=headers) as resp:
+        body = await resp.json(content_type=None)
+        _LOGGER.debug("set-session response: %s", body)
+        if body.get("code") != 0:
+            raise Exception(f"set-session failed: {body.get('message', body)}")
+        return body["data"]["companyId"]
+
+
+async def _get_app_id(session: aiohttp.ClientSession, access_token: str) -> str:
+    """GET /user/category/app/resource/list — extract appId for Univers_EMS in Smart Grid."""
+    url = f"https://home.istore.net.au/app-portal/web/v1/user/category/app/resource/list?basicType=0"
+    headers = {"Authorization": f"Bearer {access_token}"}
+    async with session.get(url, headers=headers) as resp:
+        body = await resp.json(content_type=None)
+        _LOGGER.debug("app/resource/list response: %s", body)
+        # Note: This specific endpoint returns 200 for success, unlike others that return 0
+        if body.get("code") not in (0, 200):
+            raise Exception(f"app resource list failed: {body.get('message', body)}")
+
+        categories = body["data"]["categories"]
+        for cat in categories:
+            if cat.get("name") == "Smart Grid":
+                for app in cat.get("apps", []):
+                    if app.get("code") == "Univers_EMS":
+                        return app["id"]
+        raise Exception("Could not find Univers_EMS app under Smart Grid category")
+
+
+async def _get_site_id(
+    session: aiohttp.ClientSession, access_token: str, app_id: str
+) -> str:
+    """POST /user/app/asset/tree — extract siteId for 'Istore home owner' device."""
+    url = (
+        f"https://home.istore.net.au/app-portal/web/v1/user/app/asset/tree"
+        f"?appId={app_id}&needAssociateAsset=true&resourceTypes=all"
+    )
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+    async with session.post(url, data="null", headers=headers) as resp:
+        body = await resp.json(content_type=None)
+        _LOGGER.debug("asset/tree response: %s", body)
+        if body.get("code") not in (0, 200):
+            raise Exception(f"asset tree failed: {body.get('message', body)}")
+
+        # $.data.children[?(@)].children[?(@.name=='Istore home owner')].children[?(@)].id
+        for top_child in body["data"].get("children", []):
+            for mid_child in top_child.get("children", []):
+                if mid_child.get("name") == "Istore home owner":
+                    for leaf in mid_child.get("children", []):
+                        site_id = leaf.get("id")
+                        if site_id:
+                            return site_id
+        raise Exception("Could not find site under 'Istore home owner'")
+
+
+async def _get_device_id(
+    session: aiohttp.ClientSession, access_token: str, site_id: str
+) -> str:
+    """POST /asset-hierarchy — extract mdmId for Res_WaterHeater under the given siteId."""
+    url = f"https://home.istore.net.au/encompassbffservice/encompass-bff/asset-service/v1.0/asset-hierarchy"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    payload = (
+        f"mdmIds={site_id}&mdmTypes=Res_WaterHeater"
+        "&attributes=name%2CmdmType&locale=en-US"
+    )
+    async with session.post(url, data=payload, headers=headers) as resp:
+        body = await resp.json(content_type=None)
+        _LOGGER.debug("asset-hierarchy response: %s", body)
+        if body.get("code") != 10000:
+            raise Exception(f"asset hierarchy failed: {body.get('msg', body)}")
+
+        site_data = body["data"].get(site_id, {})
+        wh_list = site_data.get("mdmObjects", {}).get("Res_WaterHeater", [])
+        if not wh_list:
+            raise Exception(f"No Res_WaterHeater device found under site {site_id}")
+        return wh_list[0]["mdmId"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public auth entry-point
+# ──────────────────────────────────────────────────────────────────────────────
+
+async def authenticate(username: str, password: str) -> dict:
+    """
+    Full login flow.
+
+    Returns a dict with keys:
+        access_token, parent_id (siteId), mdm_id (device mdmId)
+    """
+    async with aiohttp.ClientSession() as session:
+        # 1. get public key
+        pub_key_b64, strategy = await _get_public_key(session)
+
+        # 2. Encrypt password (PKCS#1 v1.5)
+        encrypted_pw = _encrypt_password(pub_key_b64, password)
+
+        # 3. Login
+        access_token, org_id = await _login(session, strategy, username, encrypted_pw)
+
+        # 4. Set session  (also validates org membership)
+        await _set_session(session, access_token, org_id)
+
+        # 5. Get App ID
+        app_id = await _get_app_id(session, access_token)
+        _LOGGER.debug("Univers_EMS appId: %s", app_id)
+
+        # 6. Get site ID / parent ID
+        parent_id = await _get_site_id(session, access_token, app_id)
+        _LOGGER.debug("site_id (parent_id): %s", parent_id)
+
+        # 7. Get device mdmId
+        mdm_id = await _get_device_id(session, access_token, parent_id)
+        _LOGGER.debug("device mdm_id: %s", mdm_id)
+
+    return {
+        "access_token": access_token,
+        "parent_id": parent_id,
+        "mdm_id": mdm_id,
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# API client
+# ──────────────────────────────────────────────────────────────────────────────
 
 class iStoreApi:
-    def __init__(self, access_token, parent_id, mdm_id, hass):
+    def __init__(self, username: str, password: str, access_token: str, parent_id: str, mdm_id: str, hass):
+        self.username = username
+        self.password = password
         self.access_token = access_token
         self.parent_id = parent_id
         self.mdm_id = mdm_id
         self.hass = hass
 
-    # ---------------------------------------------------------
-    # 1. Validate parent_id and mdm_id (Asset Hierarchy API)
-    # ---------------------------------------------------------
+    async def re_authenticate(self):
+        """Re-run the full auth flow and refresh stored credentials."""
+        _LOGGER.info("iStore: re-authenticating…")
+        creds = await authenticate(self.username, self.password)
+        self.access_token = creds["access_token"]
+        self.parent_id = creds["parent_id"]
+        self.mdm_id = creds["mdm_id"]
+        _LOGGER.info("iStore: re-authentication successful")
+
+    # -------------------------------------------------------------------------
+    # Asset hierarchy (used during config validation)
+    # -------------------------------------------------------------------------
     async def get_architecture(self):
         url = (
-            "https://home.istore.net.au/encompassbffservice/"
-            "encompass-bff/asset-service/v1.0/asset-hierarchy"
+            f"https://home.istore.net.au/encompassbffservice/encompass-bff/asset-service/v1.0/asset-hierarchy"
         )
-
         payload = {
             "mdmIds": self.parent_id,
             "mdmTypes": "Res_WaterHeater",
             "attributes": "name,mdmType",
             "locale": "en-US",
         }
-
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/x-www-form-urlencoded",
         }
-
         async with aiohttp.ClientSession() as session:
             async with session.post(url, headers=headers, data=payload) as resp:
                 text = await resp.text()
                 _LOGGER.debug("ARCHITECTURE RESPONSE: %s", text)
-
                 if resp.status != 200:
                     raise Exception(f"iStore hierarchy API failed: {resp.status}")
+                return await resp.json(content_type=None)
 
-                return await resp.json()
-
-    # ---------------------------------------------------------
-    # 2. Read measurement points (temperatures, compressor, on/off)
-    # ---------------------------------------------------------
+    # -------------------------------------------------------------------------
+    # Measurement points
+    # -------------------------------------------------------------------------
     async def get_measurements(self):
         url = (
             "https://home.istore.net.au/encompassbffservice/"
             "encompass-bff/anti-timeseries/v1.0/measurement-points"
         )
-
         POINTS = [
             "WH.OnOff",
             "WH.TargetTemp",
@@ -73,28 +273,36 @@ class iStoreApi:
             "WH.TargetTempMin",
             "WH.TargetTempMax",
         ]
-
         payload = f"mdmIds={self.mdm_id}&pointIds=" + ",".join(POINTS)
-
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
         }
-
         async with aiohttp.ClientSession() as session:
             async with session.post(url, headers=headers, data=payload) as resp:
                 text = await resp.text()
                 _LOGGER.debug("MEASUREMENTS RESPONSE: %s", text)
 
+                if resp.status == 401:
+                    _LOGGER.warning("iStore 401 on measurements — re-authenticating")
+                    await self.re_authenticate()
+                    # Retry once with new token
+                    headers["Authorization"] = f"Bearer {self.access_token}"
+                    async with session.post(url, headers=headers, data=payload) as retry:
+                        if retry.status != 200:
+                            _LOGGER.error("iStore measurement API returned %s after re-auth", retry.status)
+                            return None
+                        return await retry.json(content_type=None)
+
                 if resp.status != 200:
                     _LOGGER.error("iStore measurement API returned %s", resp.status)
                     return None
 
-                return await resp.json()
+                return await resp.json(content_type=None)
 
-    # ---------------------------------------------------------
-    # 3. Control (On / Off)
-    # ---------------------------------------------------------
+    # -------------------------------------------------------------------------
+    # Control (On / Off / Booster)
+    # -------------------------------------------------------------------------
     async def set_onoff(self, point, value):
         """Control WH.OnOff or PUB_WH.Booster."""
         url = "https://home.istore.net.au/hossain-bff/connect/v1.0/device/control"
@@ -110,80 +318,46 @@ class iStoreApi:
             {
                 "assetId": self.mdm_id,
                 "controlPointId": control_point,
-                "value": value
+                "value": value,
             }
         ]
-
         headers = {
             "Authorization": f"Bearer {self.access_token}",
             "Content-Type": "application/json",
         }
-
         async with aiohttp.ClientSession() as session:
             async with session.post(url, headers=headers, json=payload) as resp:
-                return await resp.json()
+                if resp.status == 401:
+                    _LOGGER.warning("iStore 401 on control — re-authenticating")
+                    await self.re_authenticate()
+                    headers["Authorization"] = f"Bearer {self.access_token}"
+                    async with session.post(url, headers=headers, json=payload) as retry:
+                        return await retry.json(content_type=None)
+                return await resp.json(content_type=None)
 
-
-
-    # async def set_target_temperature(self, value):
-    #     url = "https://home.istore.net.au/hossain-bff/connect/v1.0/device/control"
-    #     headers = {
-    #         "Authorization": f"Bearer {self.access_token}",
-    #         "Content-Type": "application/json",
-    #     }
-    #     payload = [
-    #         {
-    #             "assetId": self.mdm_id,
-    #             "controlPointId": "WH.TargetTemp",
-    #             "value": value
-    #         }
-    #     ]
-
-    #     async with aiohttp.ClientSession() as session:
-    #         async with session.post(url, headers=headers, json=payload) as resp:
-    #             return await resp.json()
-
-
-
-    # async def set_target_min(self, value):
-    #     url = "https://home.istore.net.au/hossain-bff/connect/v1.0/device/control"
-    #     headers = {
-    #         "Authorization": f"Bearer {self.access_token}",
-    #         "Content-Type": "application/json",
-    #     }
-    #     payload = [
-    #         {
-    #             "assetId": self.mdm_id,
-    #             "controlPointId": "WH.TargetTempMin",
-    #             "value": value
-    #         }
-    #     ]
-
-    #     async with aiohttp.ClientSession() as session:
-    #         async with session.post(url, headers=headers, json=payload) as resp:
-    #             return await resp.json()
-
-
-
-    # async def set_target_max(self, value):
-    #     url = "https://home.istore.net.au/hossain-bff/connect/v1.0/device/control"
-    #     headers = {
-    #         "Authorization": f"Bearer {self.access_token}",
-    #         "Content-Type": "application/json",
-    #     }
-    #     payload = [
-    #         {
-    #             "assetId": self.mdm_id,
-    #             "controlPointId": "WH.TargetTempMax",
-    #             "value": value
-    #         }
-    #     ]
-
-    #     async with aiohttp.ClientSession() as session:
-    #         async with session.post(url, headers=headers, json=payload) as resp:
-    #             return await resp.json()
-
-
-
-
-    
+    # -------------------------------------------------------------------------
+    # Timer control
+    # -------------------------------------------------------------------------
+    async def set_timer(self, control_point: str, value):
+        """Control a timer point (e.g. PRI_RE_WH.Timer1On)."""
+        url = "https://home.istore.net.au/hossain-bff/connect/v1.0/device/control"
+        payload = [
+            {
+                "assetId": self.mdm_id,
+                "controlPointId": control_point,
+                "value": value,
+            }
+        ]
+        headers = {
+            "Authorization": f"Bearer {self.access_token}",
+            "Content-Type": "application/json",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as resp:
+                if resp.status == 401:
+                    _LOGGER.warning("iStore 401 on timer control — re-authenticating")
+                    await self.re_authenticate()
+                    headers["Authorization"] = f"Bearer {self.access_token}"
+                    async with session.post(url, headers=headers, json=payload) as retry:
+                        return await retry.json(content_type=None)
+                return await resp.json(content_type=None)

--- a/istore_heatpump/config_flow.py
+++ b/istore_heatpump/config_flow.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
+import logging
 import voluptuous as vol
+
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN
-from .api import iStoreApi
+from .const import (DOMAIN, CONF_USERNAME, CONF_PASSWORD, CONF_ACCESS_TOKEN, CONF_PARENT_ID, CONF_MDM_ID)
+from .api import authenticate
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class CannotConnect(HomeAssistantError):
@@ -16,58 +21,44 @@ class InvalidAuth(HomeAssistantError):
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 1
+    VERSION = 2
 
     async def async_step_user(self, user_input=None):
         errors = {}
 
         if user_input is not None:
-            access_token = user_input["access_token"]
-            parent_id = user_input["parent_id"]
-            mdm_id = user_input["mdm_id"]
-
-            api = iStoreApi(access_token, parent_id, mdm_id, self.hass)
+            username = user_input[CONF_USERNAME]
+            password = user_input[CONF_PASSWORD]
 
             try:
-                arch = await api.get_architecture()
-
-                # Validate response format
-                if "data" not in arch or parent_id not in arch["data"]:
-                    raise InvalidAuth
-
-                # Validate Res_WaterHeater exists
-                objs = arch["data"][parent_id].get("mdmObjects", {})
-                if "Res_WaterHeater" not in objs:
-                    raise InvalidAuth
-
-                # Validate mdm_id exists inside Res_WaterHeater
-                mdm_list = objs["Res_WaterHeater"]
-                found = any(obj.get("mdmId") == mdm_id for obj in mdm_list)
-
-                if not found:
-                    raise InvalidAuth
-
+                creds = await authenticate(username, password)
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
-            except Exception as e:
-                # Print full error to logs
-                import logging
-                logging.getLogger(__name__).error("Config flow error: %s", e)
-                errors["base"] = "cannot_connect"
-
-            if not errors:
-                # Successfully validated
+            except Exception as exc:
+                _LOGGER.error("iStore config flow error: %s", exc)
+                # Try to give a nicer error for auth failures vs connectivity
+                msg = str(exc).lower()
+                if "login failed" in msg or "invalid" in msg or "401" in msg:
+                    errors["base"] = "invalid_auth"
+                else:
+                    errors["base"] = "cannot_connect"
+            else:
+                # Persist username, password, and discovered IDs
                 return self.async_create_entry(
                     title="iStore Heat Pump",
-                    data=user_input,
+                    data={
+                        CONF_USERNAME: username,
+                        CONF_PASSWORD: password,
+                        CONF_ACCESS_TOKEN: creds["access_token"],
+                        CONF_PARENT_ID: creds["parent_id"],
+                        CONF_MDM_ID: creds["mdm_id"],
+                    },
                 )
 
-        # Form schema
         data_schema = vol.Schema(
             {
-                vol.Required("access_token"): str,
-                vol.Required("parent_id"): str,
-                vol.Required("mdm_id"): str,
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
             }
         )
 

--- a/istore_heatpump/const.py
+++ b/istore_heatpump/const.py
@@ -1,1 +1,8 @@
 DOMAIN = "istore_heatpump"
+
+# Config entry keys
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+CONF_ACCESS_TOKEN = "access_token"
+CONF_PARENT_ID = "parent_id"
+CONF_MDM_ID = "mdm_id"

--- a/istore_heatpump/manifest.json
+++ b/istore_heatpump/manifest.json
@@ -3,10 +3,18 @@
   "name": "iStore Heat Pump",
   "version": "1.0.0",
   "documentation": "https://example.com",
-  "requirements": [],
-  "codeowners": ["@yourname"],
+  "requirements": [
+    "cryptography>=41.0.0"
+  ],
+  "codeowners": [
+    "@yourname"
+  ],
   "iot_class": "cloud_polling",
   "config_flow": true,
   "integration_type": "hub",
-  "platforms": ["sensor", "switch", "binary_sensor"]
+  "platforms": [
+    "sensor",
+    "switch",
+    "binary_sensor"
+  ]
 }

--- a/istore_heatpump/strings.json
+++ b/istore_heatpump/strings.json
@@ -1,0 +1,22 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "title": "iStore Heat Pump",
+                "description": "Enter your iStore account credentials.",
+                "data": {
+                    "username": "Username (email address)",
+                    "password": "Password"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "Failed to connect to the iStore cloud. Check your network and try again.",
+            "invalid_auth": "Invalid username or password.",
+            "unknown": "An unexpected error occurred. Check the Home Assistant logs for details."
+        },
+        "abort": {
+            "already_configured": "iStore Heat Pump is already configured."
+        }
+    }
+}


### PR DESCRIPTION
# Updated Auth Flow

## Change

The integration no longer requires the user to manually obtain an `access_token`, `parent_id`, or `mdm_id`. The user only enters their **username** and **password**.

### Files Modified

| File | Change |
|------|--------|
| [api.py](file:///c:/iStore-git/istore-ha/istore_heatpump/api.py) | Complete rewrite — added full login chain + auto re-auth on 401 |
| [config_flow.py](file:///c:/iStore-git/istore-ha/istore_heatpump/config_flow.py) | Replaced 3-field form with username/password |
| [__init__.py](file:///c:/iStore-git/istore-ha/istore_heatpump/__init__.py) | Reads username/password from entry data |
| [const.py](file:///c:/iStore-git/istore-ha/istore_heatpump/const.py) | Added URL bases + config key constants |
| [manifest.json](file:///c:/iStore-git/istore-ha/istore_heatpump/manifest.json) | Added `cryptography>=41.0.0` requirement |

### Files Added

| File | Purpose |
|------|---------|
| [strings.json](file:///c:/iStore-git/istore-ha/istore_heatpump/strings.json) | Config flow UI labels & error messages |

---

## Authentication Chain

```mermaid
sequenceDiagram
    participant HA as Home Assistant
    participant API as iStore API

    HA->>API: GET /user/public-key
    API-->>HA: publicKey (RSA 2048), strategy
    Note over HA: Encrypt with RSA-OAEP / SHA-256
    HA->>API: POST /user/login (encrypted password)
    API-->>HA: accessToken + orgId
    HA->>API: POST /user/set-session (orgId)
    API-->>HA: companyId
    HA->>API: GET /user/category/app/resource/list
    API-->>HA: appId for Univers_EMS
    HA->>API: POST /user/app/asset/tree (appId)
    API-->>HA: siteId (parentId) under "Istore home owner"
    HA->>API: POST /asset-hierarchy (siteId)
    API-->>HA: mdmId for Res_WaterHeater
```

---

## Token Refresh

If any API call receives a `401`, the integration automatically re-runs the full login chain using the stored credentials and retries the request once. No manual intervention is needed.

---

## TO DO:
README.md will need to be updated with new configuration steps.